### PR TITLE
Add mkdocs markdown include plugin

### DIFF
--- a/template/Taskfile.yml
+++ b/template/Taskfile.yml
@@ -33,6 +33,11 @@ tasks:
       - uv run ruff check .
       - uv run mypy
 
+  docs:
+    desc: Build the documentation
+    cmds:
+      - uv run mkdocs build --clean
+
   check:
     desc: Run all the checks
     cmds:

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -36,6 +36,7 @@ dev-dependencies = [
   "ruff>=0.6.2",
   "mkdocs>=1.6.0",
   "mkdocs-material>=9.5.33",
+  "mkdocs-include-markdown-plugin>=6.2.2",
 ]
 
 [tool.pytest.ini_options]
@@ -70,9 +71,6 @@ enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]
 
 [tool.ruff]
 line-length = 120
-extend-exclude = [
-  "template/**/*", # Gets confused inside the template
-]
 
 [tool.ruff.format]
 # https://docs.astral.sh/ruff/settings/#format


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Initial release was missing <https://pypi.org/project/mkdocs-include-markdown-plugin/> from dev dependencies.

Also added a `docs` task to build the project docs
